### PR TITLE
Fix and Dep change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ spec/fixtures
 # these get in the way of our travis builds
 .ruby-version
 Gemfile.lock
+.project

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 sudo: false
 language: ruby
 bundler_args: --without system_tests
-script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake spec"
+script: bundle exec rake spec
 matrix:
   fast_finish: true
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,16 @@
+---
+sudo: false
 language: ruby
-rvm:
- - 1.8.7
- - 2.0.0
-
-script: "bundle exec rake spec"
-
-branches:
-  only:
-      - master
-      - /^issues\/.*$/
-      - dev
-
-notifications:
-  email:
-    - arusso@berkeley.edu
-
-env:
-  - PUPPET_VERSION="~> 2.7.0"
-  - PUPPET_VERSION="~> 3.1.0"
-  - PUPPET_VERSION="~> 3.2.0"
-  - PUPPET_VERSION="~> 3.3.0"
-  - PUPPET_VERSION="~> 3.4.0"
-
+bundler_args: --without system_tests
+script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake spec"
 matrix:
-  exclude:
-    - rvm: 2.0.0
-      env: PUPPET_VERSION="~> 2.7.0"
-    - rvm: 2.0.0
-      env: PUPPET_VERSION="~> 3.0.0"
-    - rvm: 2.0.0
-      env: PUPPET_VERSION="~> 3.1.0"
+  fast_finish: true
+  include:
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 2.1.5
+    env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 2.1.6
+    env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
+notifications:
+  email: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,18 @@
 require 'rubygems'
 require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
+
+desc "Validate manifests, templates, and ruby files"
+task :validate do
+  Dir['manifests/**/*.pp'].each do |manifest|
+    sh "puppet parser validate --noop #{manifest}"
+  end
+  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
+    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
+  end
+  Dir['templates/**/*.erb'].each do |template|
+    sh "erb -P -x -T '-' #{template} | ruby -c"
+  end
+end

--- a/manifests/ipv6/rule.pp
+++ b/manifests/ipv6/rule.pp
@@ -43,7 +43,7 @@ define iptables::ipv6::rule ( $options = undef, $defaults = undef ) {
   # TODO: pretty sure the following line is a bug preventing IPv6 chains other
   #       than the ADMIN and INPUT chain. Nobody has complained though, so
   #       maybe I'm forgetting while we need this?
-  if ! $chain =~  /^(ADMIN|INPUT)$/ { fail( "chain - ${chain}") }
+  if $chain !~  /^(ADMIN|INPUT)$/ { fail( "chain - ${chain}") }
   $chain_order_arr = member( $builtin, $chain ) ? {
     true    => [ $order['chain'][$chain], $chain ],
     default => [ $order['chain']['other'], $chain ],

--- a/manifests/ipv6/rule.pp
+++ b/manifests/ipv6/rule.pp
@@ -43,6 +43,7 @@ define iptables::ipv6::rule ( $options = undef, $defaults = undef ) {
   # TODO: pretty sure the following line is a bug preventing IPv6 chains other
   #       than the ADMIN and INPUT chain. Nobody has complained though, so
   #       maybe I'm forgetting while we need this?
+  # Fix for github issue #23
   if $chain !~  /^(ADMIN|INPUT)$/ { fail( "chain - ${chain}") }
   $chain_order_arr = member( $builtin, $chain ) ? {
     true    => [ $order['chain'][$chain], $chain ],

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "project_page": "https://github.com/arusso/puppet-iptables",
   "description": "iptables management module that updates the iptables save file,\n  without changing the running state of iptables.",
   "dependencies": [
-    {"version_requirement":">= 0.2.0","name":"ripienaar/concat"},
+    {"version_requirement":">= 1.0.0","name":"puppetlabs/concat"},
     {"version_requirement":">= 0.0.1","name":"arusso/oski"},
     {"version_requirement":">= 2.6.0","name":"puppetlabs/stdlib"}
   ],


### PR DESCRIPTION
Replaced the ripienaar/concat dependency with puppetlabs/concat. (Issue #23)

Removed Boolean operator for the $chain variable in ipv6/rule.pp changed the =~ regex operator to !~ operator. should have the same effect. Tested and validated on Puppet Enterprise 2015.2 and Puppet 4.2.1 (Issue #24 )