### PR TITLE
improved chain variable check in ipv6/rule.pp define

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ spec/fixtures
 # these get in the way of our travis builds
 .ruby-version
 Gemfile.lock
+.project

--- a/manifests/ipv6/rule.pp
+++ b/manifests/ipv6/rule.pp
@@ -43,7 +43,7 @@ define iptables::ipv6::rule ( $options = undef, $defaults = undef ) {
   # TODO: pretty sure the following line is a bug preventing IPv6 chains other
   #       than the ADMIN and INPUT chain. Nobody has complained though, so
   #       maybe I'm forgetting while we need this?
-  if ! $chain =~  /^(ADMIN|INPUT)$/ { fail( "chain - ${chain}") }
+  if $chain !~  /^(ADMIN|INPUT)$/ { fail( "chain - ${chain}") }
   $chain_order_arr = member( $builtin, $chain ) ? {
     true    => [ $order['chain'][$chain], $chain ],
     default => [ $order['chain']['other'], $chain ],


### PR DESCRIPTION
@arusso - 
"Error 400 on SERVER: Evaluation Error: Left match operand must result in a String value. Got a Boolean" being thrown when code attempts to validate that $chain contains INPUT or ADMIN in the ipv6/rule.pp define type. Appears to affect Puppet version 4.2.1 (affects Puppet Enterprise 2015.2 and Puppet Open Source 4.2.1).

Logic now checks if "$chain does not contain ADMIN or INPUT" then do work, rather than if "$chain contains ADMIN or INPUT return true" then don't do work.

See issue #24 