### PR TITLE
fixed issue with concat >= 2.0.0, verified operation on CentOS 7

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,7 +19,6 @@ class iptables (
   $ip6tables_file = 'UNSET',
   $version = 'UNSET',
 ) {
-  include concat::setup
 
   ##############################################################################
   # Parameter Validation

--- a/metadata.json
+++ b/metadata.json
@@ -9,14 +9,14 @@
   "project_page": "https://github.com/arusso/puppet-iptables",
   "description": "iptables management module that updates the iptables save file,\n  without changing the running state of iptables.",
   "dependencies": [
-    {"version_requirement":">= 1.0.0","name":"puppetlabs/concat"},
+    {"version_requirement":">= 2.0.0","name":"puppetlabs/concat"},
     {"version_requirement":">= 0.0.1","name":"arusso/oski"},
     {"version_requirement":">= 4.2.0","name":"puppetlabs/stdlib"}
   ],
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",
-      "operatingsystemrelease": [ "5", "6" ]
+      "operatingsystemrelease": [ "5", "6", "7" ]
     }
   ],
   "tags": [


### PR DESCRIPTION
I realize this module seems inactive, but quite frankly, it is exactly what I needed, but in order to support a more recent release of concat, I am offering this pull request. I also added Redhat (CentOS) 7 to metadata, as that is the OS I am working with.